### PR TITLE
feat: Propagate additional capabilities for nodemanager if available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,7 +219,7 @@ FROM ubuntu:focal AS hadoop-base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get -q update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -q install --yes --no-upgrade --no-install-recommends tzdata curl ca-certificates fontconfig locales libsnappy1v5 libzstd1 zlib1g libbz2-1.0 libssl1.1 libc6-dbg tini gosu && \
+  DEBIAN_FRONTEND=noninteractive apt-get -q install --yes --no-upgrade --no-install-recommends tzdata curl ca-certificates fontconfig locales libsnappy1v5 libzstd1 zlib1g libbz2-1.0 libssl1.1 libc6-dbg tini && \
   ARCH="$(dpkg --print-architecture)" && \
   case "${ARCH}" in \
     amd64|i386:x86-64) \
@@ -288,18 +288,20 @@ CMD ["/usr/sbin/sshd", "-D", "-e"]
 
 FROM hadoop-base AS hadoop-hdfs-datanode
 COPY --chown=root:root ./hadoop-hdfs-datanode/docker-entrypoint.d /docker-entrypoint.d
-CMD ["gosu", "hdfs", "hdfs", "datanode"]
+CMD ["hdfs", "datanode"]
 
 FROM hadoop-base AS hadoop-hdfs-namenode
 COPY --chown=root:root ./hadoop-hdfs-namenode/docker-entrypoint.d /docker-entrypoint.d
-CMD ["gosu", "hdfs", "hdfs", "namenode"]
+CMD ["hdfs", "namenode"]
 
 FROM hadoop-base AS hadoop-mapred-jobhistoryserver
 COPY --chown=root:root ./hadoop-mapred-jobhistoryserver/docker-entrypoint.d /docker-entrypoint.d
-CMD ["gosu", "mapred", "mapred", "historyserver"]
+CMD ["mapred", "historyserver"]
 
 FROM hadoop-base AS hadoop-yarn-nodemanager
-CMD ["gosu", "yarn", "yarn", "nodemanager"]
+COPY --chown=root:root ./hadoop-yarn-nodemanager/docker-entrypoint.d /docker-entrypoint.d
+CMD ["yarn", "nodemanager"]
 
 FROM hadoop-base AS hadoop-yarn-resourcemanager
-CMD ["gosu", "yarn", "yarn", "resourcemanager"]
+COPY --chown=root:root ./hadoop-yarn-resourcemanager/docker-entrypoint.d /docker-entrypoint.d
+CMD ["yarn", "resourcemanager"]

--- a/hadoop-base/docker-entrypoint.sh
+++ b/hadoop-base/docker-entrypoint.sh
@@ -26,4 +26,8 @@ docker_process_init_files() {
 
 docker_process_init_files docker-entrypoint.d/*
 
-exec "$@"
+export SETPRIV_REUID="${SETPRIV_REUID:-root}"
+export SETPRIV_REGID="${SETPRIV_REGID:-root}"
+export SETPRIV_CAP_OPTS="${SETPRIV_CAP_OPTS:-}"
+
+exec setpriv --reuid="${SETPRIV_REUID}" --regid="${SETPRIV_REGID}" --init-groups ${SETPRIV_CAP_OPTS} -- "$@"

--- a/hadoop-client/docker-entrypoint.d/10-mkdir-user-home.sh
+++ b/hadoop-client/docker-entrypoint.d/10-mkdir-user-home.sh
@@ -2,5 +2,5 @@
 set -Eeo pipefail
 
 install -d -o sandbox -g sandbox 755 /home/sandbox
-gosu hdfs hdfs dfs -mkdir -p /user/sandbox
-gosu hdfs hdfs dfs -chown sandbox:sandbox /user/sandbox
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -mkdir -p /user/sandbox
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -chown sandbox:sandbox /user/sandbox

--- a/hadoop-hdfs-datanode/docker-entrypoint.d/50-setpriv.sh
+++ b/hadoop-hdfs-datanode/docker-entrypoint.d/50-setpriv.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+export SETPRIV_REUID=hdfs
+export SETPRIV_REGID=hdfs
+export SETPRIV_CAP_OPTS=""
+

--- a/hadoop-hdfs-namenode/docker-entrypoint.d/10-format-hdfs.sh
+++ b/hadoop-hdfs-namenode/docker-entrypoint.d/10-format-hdfs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeo pipefail
-if ! gosu hdfs hdfs namenode -metadataVersion; then
-   gosu hdfs hdfs namenode -format -nonInteractive
+if ! setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs namenode -metadataVersion; then
+   setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs namenode -format -nonInteractive
 fi
 

--- a/hadoop-hdfs-namenode/docker-entrypoint.d/50-setpriv.sh
+++ b/hadoop-hdfs-namenode/docker-entrypoint.d/50-setpriv.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+export SETPRIV_REUID=hdfs
+export SETPRIV_REGID=hdfs
+export SETPRIV_CAP_OPTS=""
+

--- a/hadoop-mapred-jobhistoryserver/docker-entrypoint.d/10-mkdir-mr-history.sh
+++ b/hadoop-mapred-jobhistoryserver/docker-entrypoint.d/10-mkdir-mr-history.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeo pipefail
-gosu hdfs hdfs dfs -mkdir -p /mr-history
-gosu hdfs hdfs dfs -mkdir -p /tmp
-gosu hdfs hdfs dfs -chmod 1777 /tmp
-gosu hdfs hdfs dfs -chmod 755 /mr-history
-gosu hdfs hdfs dfs -chown mapred:hadoop /mr-history
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -mkdir -p /mr-history
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -mkdir -p /tmp
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -chmod 1777 /tmp
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -chmod 755 /mr-history
+setpriv --reuid=hdfs --regid=hdfs --init-groups hdfs dfs -chown mapred:hadoop /mr-history

--- a/hadoop-mapred-jobhistoryserver/docker-entrypoint.d/50-setpriv.sh
+++ b/hadoop-mapred-jobhistoryserver/docker-entrypoint.d/50-setpriv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+export SETPRIV_REUID=mapred
+export SETPRIV_REGID=mapred
+export SETPRIV_CAP_OPTS=""

--- a/hadoop-yarn-nodemanager/docker-entrypoint.d/50-setpriv.sh
+++ b/hadoop-yarn-nodemanager/docker-entrypoint.d/50-setpriv.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+export SETPRIV_REUID=yarn
+export SETPRIV_REGID=yarn
+
+# sys_admin and syslog capabilities allow async-profiler to work if host has
+#
+# kernel.perf_event_paranoid in (-1, 0, 1, 2) AND
+# kernel.kptr_restrict in (0, 1)
+#
+# see:
+# https://github.com/jvm-profiling-tools/async-profiler/blob/master/README.md
+# https://sysctl-explorer.net/kernel/perf_event_paranoid/
+# https://sysctl-explorer.net/kernel/kptr_restrict/
+if setpriv "--reuid=${SETPRIV_REUID}" "--regid=${SETPRIV_REGID}" --init-groups --inh-caps +sys_admin,+syslog --ambient-caps +sys_admin,+syslog -- true; then
+    echo "Enabling additional capabilities"
+    export SETPRIV_CAP_OPTS="--inh-caps +sys_admin,+syslog --ambient-caps +sys_admin,+syslog"
+else
+    echo "Not enabling additional capabilities"
+    export SETPRIV_CAP_OPTS=""
+fi

--- a/hadoop-yarn-resourcemanager/docker-entrypoint.d/50-setpriv.sh
+++ b/hadoop-yarn-resourcemanager/docker-entrypoint.d/50-setpriv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+export SETPRIV_REUID=yarn
+export SETPRIV_REGID=yarn
+export SETPRIV_CAP_OPTS=""


### PR DESCRIPTION
Allows to use async-profiler without sysctl on host. As a side-effect,
gosu dependency was replaced with setpriv.